### PR TITLE
Move pnpm overrides into workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,5 @@
     "commitizen": {
       "path": "cz-conventional-changelog"
     }
-  },
-  "pnpm": {
-    "overrides": {
-      "sharp": "0.34.5"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - 'app/*'
   - 'packages/*'
+
+overrides:
+  sharp: 0.34.5


### PR DESCRIPTION
## Summary

- Move the `sharp` override from `package.json` into `pnpm-workspace.yaml`.
- Keep the lockfile-compatible pnpm override in the config file current pnpm expects.

## Why

A clean `pnpm install --frozen-lockfile --ignore-scripts` failed with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` because the `pnpm` field in `package.json` is ignored for overrides. Moving the override to the workspace config in `pnpm-workspace.yaml` made the frozen install pass.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm build`
- `pnpm typecheck`

No runtime logic changed.
